### PR TITLE
Lean is easier to make

### DIFF
--- a/code/modules/reagents/recipes/recipes.dm
+++ b/code/modules/reagents/recipes/recipes.dm
@@ -365,7 +365,7 @@
 
 /datum/chemical_reaction/lean
 	result = "lean"
-	required_reagents = list("oxycodone" = 1, "chloralhydrate" = 1, "stoxin" = 1, "sodawater" = 1)
+	required_reagents = list("tramadol" = 1, "chloralhydrate" = 1, "stoxin" = 1, "sodawater" = 1)
 	byproducts= list("redcandyliquor" = 1) //Its called old fastion sleeping agent
 	result_amount = 1
 


### PR DESCRIPTION
Lean is inferior to pure oxycodone in every way, while its a fun party drug, there's little to no advantage of actually trying to make it as it requires said oxycodone to produce currently.

IRL lean only uses weaker opiates traditionally, like codeine and tramadol.